### PR TITLE
Schriftart und Farben mit Werten von ZG ersetzt

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -6,8 +6,7 @@
     <meta name="viewport" content="width=device-width,initial-scale=1">
     
     <link rel="stylesheet" href="/assets/css/zitronenblau.css">
-    <link href="https://fonts.googleapis.com/css2?family=Nunito:wght@200;300;400;500;700;1000&display=swap" rel="stylesheet"> 
-    
+
     <!-- JS at end of page for performance -->
     
     {% if page.header_code %}

--- a/assets/css/01_base.css
+++ b/assets/css/01_base.css
@@ -1,14 +1,21 @@
+@import url(https://use.typekit.net/ltq7cop.css);
+
 /* This is vanilla CSS, which supports variables. Welcome to 2022! :) */
 /* foo-ish (en) = foo-lich (de) */
 :root {
     /* Color palette with weird names */
     --blueish: #1a69e9;
-    --lightblue: #8cb4f4;
-    --greenish: #00ffb5;
-    --reddish: #ff6478;
-    --whiteish: #ffffff;
     --greyish: #f5f5f5;
-    
+    --yellowish: #fcc53d;
+    --reddish: #ff6478;
+    --greenish: #05ffb5;
+    --tealish: #46d8dc;
+    --darkblueish: #00353e;
+
+    /* off-palette colors */
+    --lightblue: #8cb4f4;
+    --whiteish: #ffffff;
+
     /* Breakpoints */
     --xs: 576px;
     --sm: 768px;

--- a/assets/css/02_header_footer_nav.css
+++ b/assets/css/02_header_footer_nav.css
@@ -3,7 +3,7 @@ html, body {
     margin: 0;
     padding: 0;
     
-    font-family: 'Nunito', sans-serif;
+    font-family: "nunito", sans-serif;
 }
 
 .blue {


### PR DESCRIPTION
Zitronenblau hat in unserem Logo Adobe Nunito verwendet, was leicht von Google abweicht -> Font getauscht
Farben aus Zitronenblau Palette vervollständigt, siehe https://youtrack.intern.denktmit.tech/articles/www-A-3/Coorporate-Design